### PR TITLE
Properly initialize StringBuilder with the right buffer size

### DIFF
--- a/src/Core/MessageBus.cs
+++ b/src/Core/MessageBus.cs
@@ -103,8 +103,8 @@ namespace GenshinPlayerQuery.Core
         public static string GetBrowserLoginTicket()
         {
             const string url = COOKIE_URL;
-            StringBuilder loginTicket = new StringBuilder();
-            uint size = 256;
+            StringBuilder loginTicket = new StringBuilder(255);
+            uint size = Convert.ToUInt32(loginTicket.Capacity + 1);
             InternetGetCookieEx(url, COOKIE_NAME_LOGIN_TICKET, loginTicket, ref size, COOKIE_HTTP_ONLY, IntPtr.Zero);
             return loginTicket.ToString();
         }


### PR DESCRIPTION
现象：当本地储存的cookie无效时，程序会在登录后崩溃。
原因：在MessageBus.GetBrowserLoginTicket中调用InternetGetCookieEx时，传入的缓冲区大小为256（包含结尾NULL），而默认StringBuilder分配的缓冲区大小为17（包含结尾NULL），造成缓冲区溢出。
解决方案：依照[微软文档](https://docs.microsoft.com/en-us/dotnet/framework/interop/default-marshaling-for-strings#fixed-length-string-buffers)来分配正确大小的缓冲区。